### PR TITLE
Handle web workers

### DIFF
--- a/template.js
+++ b/template.js
@@ -23,8 +23,10 @@
   } else {
     if (typeof window !== "undefined") {
       window.{{camelcase}} = f();
-    } else {
+    } else if (typeof global !== "undefined") {
       global.{{camelcase}} = f();
+    } else if (typeof self !== "undefined") {
+      self.{{camelcase}} = f();
     }
   }
 


### PR DESCRIPTION
In web workers, umd tries to access `global` which is undefined. This fixes it using `self`instead.
