### PR TITLE
Pass empty dependency array for AMD to prevent dependency scanning

### DIFF
--- a/template.js
+++ b/template.js
@@ -5,7 +5,7 @@
 
   // RequireJS
   } else if (typeof define === "function" && define.amd) {
-    define(f);
+    define([], f);
 
   // <script>
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -14,8 +14,8 @@ describe('with CommonJS', function () {
 describe('with amd', function () {
   it('uses define', function () {
     var defed
-    function define(fn) {
-      defed = fn()
+    function define(d, fn) {
+      defed = (typeof d === 'function' ? d: fn)()
     }
     define.amd = true
     Function('define', src)(define)


### PR DESCRIPTION
AMD loaders will scan for `require('dep')` style dependencies when just a factory function is passed to define (no dependency array). Now that projects may use CommonJS/Node modules internal to source function to generate the final exports, this is causing some undesired matching behavior, the AMD loader may also try to load modules for those `require('dep')` names. 

Passing an empty dependency array, as this changeset does, avoids that factory function scanning and possible confusion around if the UMD-wrapped code has dependencies.
