### PR TITLE
Allow to have dots on names and namespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,12 +52,12 @@ exports.postlude = function (moduleName, cjs) {
 
 function camelCase(name) {
   name = name.replace(/\-([a-z])/g, function (_, char) { return char.toUpperCase(); });
-  return name.replace(/[^a-zA-Z0-9]+/g, '')
+  return name.replace(/\W+/g, '')
 }
 
 
 function compileNamespace(name) {
-  var names = name.split('.')
+  var names = name.split('/')
 
   // No namespaces, yield the best case 'global.NAME = VALUE'
   if (names.length === 1) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   {
     "name": "Jesús Leganés Combarro 'piranna'",
     "email": "piranna@gmail.com",
-    "web": "http://pirannafs.blogspot.com",
+    "web": "http://pirannafs.blogspot.com"
   }],
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umd",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Universal Module Definition for use in automated build systems",
   "bin": "./bin/cli.js",
   "dependencies": {
@@ -21,6 +21,13 @@
     "type": "git",
     "url": "https://github.com/ForbesLindesay/umd.git"
   },
-  "author": "ForbesLindesay",
+  "contributors":[ {
+    "name": "ForbesLindesay"
+  },
+  {
+    "name": "Jesús Leganés Combarro 'piranna'",
+    "email": "piranna@gmail.com",
+    "web": "http://pirannafs.blogspot.com",
+  }],
   "license": "MIT"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,10 @@
 var assert = require('assert')
 var umd = require('../')
 var src = umd('sentinel-prime', 'return "sentinel"')
-var namespacedSrc = umd('sentinel.prime', 'return "sentinel"')
-var multiNamespaces = umd('a.b.c.d.e', 'return "sentinel"')
+var namespacedSrc = umd('sentinel/prime', 'return "sentinel"')
+var multiNamespaces = umd('a/b/c/d/e', 'return "sentinel"')
+var dottedSrc = umd('sentinel.prime', 'return "sentinel"')
+var dottedNamespaces = umd('a/b.c/d.e/f', 'return "sentinel"')
 
 describe('with CommonJS', function () {
   it('uses module.exports', function () {
@@ -49,4 +51,14 @@ describe('in the absense of a module system', function () {
     assert(glob.a.b.c.d.e === 'sentinel')
   })
 
+  it('allow dots in names', function() {
+    var glob = {}
+    Function('window', dottedSrc)(glob)
+    assert(glob.sentinelprime === 'sentinel')
+  })
+  it('allow dots in names and namespaces', function() {
+    var glob = {}
+    Function('window', dottedNamespaces)(glob)
+    assert(glob.a.bc.de.f === 'sentinel')
+  })
 })


### PR DESCRIPTION
According to http://wiki.commonjs.org/wiki/Packages/1.0, dots are allowed to be used on CommonJS packages names. This change use slashes (that's a not allowed character) to be used as namespaces separator and restored the previous behaviour by just removing the dots. An alternative, more compliant option would be to allow to use them in the namespaces names, but this would require to access to them using brackets instead of object notation.