### PR TITLE
Add to global with string keys instead of dot notation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var uglify = require('uglify-js');
 function template(moduleName, cjs) {
   var str = uglify.minify(
     templateSTR.replace(/\{\{defineNamespace\}\}/g, compileNamespace(moduleName)),
-    {fromString: true}).code
+    {fromString: true, compress: {properties: false}}).code
     .split('source()')
   str[0] = str[0].trim();
   //make sure these are undefined so as to not get confused if modules have inner UMD systems

--- a/index.js
+++ b/index.js
@@ -61,24 +61,24 @@ function compileNamespace(name) {
 
   // No namespaces, yield the best case 'global.NAME = VALUE'
   if (names.length === 1) {
-    return 'g.' + camelCase(name) + ' = f()';
+    return "g['" + camelCase(name) + "'] = f()";
 
   // Acceptable case, with reasonable compilation
   } else if (names.length === 2) {
     names = names.map(camelCase);
-    return '(g.' + names[0] + ' || (g.' + names[0] + ' = {})).' + names[1] + ' = f()';
+    return "(g['" + names[0] + "'] || (g['" + names[0] + "'] = {}))['" + names[1] + "'] = f()";
 
   // Worst case, too many namespaces to care about
   } else {
     var valueContainer = names.pop()
     return names.reduce(compileNamespaceStep, ['var ref$ = g'])
-                .concat(['ref$.' + camelCase(valueContainer) + ' = f()'])
+                .concat(["ref$['" + camelCase(valueContainer) + "'] = f()"])
                 .join(';\n    ');
   }
 }
 
 function compileNamespaceStep(code, name, i, names) {
   name = camelCase(name);
-  code.push('ref$ = (ref$.' + name + ' || (ref$.' + name + ' = {}))')
+  code.push("ref$ = (ref$['" + name + "'] || (ref$['" + name + "'] = {}))")
   return code
 }


### PR DESCRIPTION
When compiling with Google Closure Compiler the preferred method of preventing variable rewriting is to assign with strings instead of dot notation as then the compiler won't rewrite the names.

This pull request replaces the dot notation with string keys for adding variables to the global object (window, self, global etc.)