### PR TITLE
Fix a case for custom RequireJS loader

### DIFF
--- a/template.js
+++ b/template.js
@@ -1,6 +1,6 @@
 ;(function (f) {
   // CommonJS
-  if (typeof exports === "object") {
+  if (typeof exports === "object" && typeof module !== "undefined") {
     module.exports = f();
 
   // RequireJS


### PR DESCRIPTION
When using packages built by browserify which uses this in [Brackets](http://brackets.io/), some users get an `module is not defined` exception because loading doesn't get to `RequireJS` case.

Related issue:
https://github.com/zaggino/brackets-git/issues/277
https://github.com/kriskowal/q/pull/391
