### PR TITLE
Allow for the specification of amd deps to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,25 @@ For examples, see the examples directory.  The CommonJS module format is also su
 
 ## API
 
-### umd(name, [commonJS = false], [source])
+### umd(name, [commonJS = false], [source], [options])
 
   The `name` should the the name of the module.  Use a string like name, all lower case with hyphens instead of spaces.
 
   If CommonJS is `true` then it will accept CommonJS source instead of source code which `return`s the module.
 
   If `source` is provided and is a string, then it is wrapped in umd and returned as a string.  If it is not provided, a duplex stream is returned which wraps the modules (see examples/build.js).
-
+  
   Both commonJS and source are optional and can be provided in either order.
+  
+  If `options` is provided and is an object, it will be passed as configuration to `umd.prelude`
+  
+  `options` must always be passed as the fourth parameter.
 
-### umd.prelude(module, [commonJS = false])
+### umd.prelude(module, [commonJS = false], [options = {}])
 
   return the text which will be inserted before a module.
+  
+  If `options.amd.deps` is an array of strings, it will be provided as the list of dependencies for the amd portion of the umd header. This allows wrapped code to use the short form of RequireJS to load the modules.
 
 ### umd.postlude(module, [commonJS = false])
 

--- a/template.js
+++ b/template.js
@@ -5,7 +5,7 @@
 
   // RequireJS
   } else if (typeof define === "function" && define.amd) {
-    define([], f);
+    define([{{amdDependencies}}], f);
 
   // <script>
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ var umd = require('../')
 var src = umd('sentinel-prime', 'return "sentinel"')
 var namespacedSrc = umd('sentinel.prime', 'return "sentinel"')
 var multiNamespaces = umd('a.b.c.d.e', 'return "sentinel"')
+var amdDeps = umd('sentinel-prime', 'return "sentinel"', undefined, { amd: { deps: ['dep1', 'dep2'] } });
 
 describe('with CommonJS', function () {
   it('uses module.exports', function () {
@@ -24,6 +25,9 @@ describe('with amd', function () {
     Function('define', src)(define)
     assert(defed === 'sentinel')
   })
+  it('uses the provided dependency array so the shorthand version of require can be used', function () {
+    assert(amdDeps.indexOf('["dep1","dep2"]') > -1);
+  });
 })
 describe('in the absense of a module system', function () {
   it('uses window', function () {


### PR DESCRIPTION
This allows for RequireJS's short form (http://requirejs.org/docs/api.html#cjsmodule) require to be used in wrapped
code and will allow for modules produced with browserify to use external
modules when loaded with AMD.

e.g.

``` js
;(function (f) {
  // CommonJS
  //...
  // RequireJS
  } else if (typeof define === "function" && define.amd) {
    define(["underscore"], f);

  // <script>
  } else {
  //...
})(function () {
var _ = require('underscore');
//...
});
```

This lays the foundation to address https://github.com/substack/node-browserify/issues/670 and https://github.com/substack/node-browserify/issues/801
