### PR TITLE
Remove unused dependency "ruglify"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "bin": "./bin/cli.js",
   "dependencies": {
     "rfile": "~1.0.0",
-    "ruglify": "~1.0.0",
     "through": "~2.3.4",
     "uglify-js": "~2.4.0"
   },


### PR DESCRIPTION
Little bit of housekeeping. This will reduce the total size of `umd` by 1.2MB (since `ruglify` depends on `uglify ~2.2`, `npm` can't dedupe it with `uglify ~2.4.0`).