### PR TITLE
Use camelize-identifier to validate and camel case the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The `name` passed to `umd` will be converted to camel case (`my-library` becomes
 * $
 * _
 
-The name may not begin with a number. Invalid characters will be stripped. 
+The name may not begin with a number. `umd` will throw if the provided `name` is invalid. 
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "3.0.1",
   "description": "Universal Module Definition for use in automated build systems",
   "bin": "./bin/cli.js",
-  "dependencies": {},
+  "dependencies": {
+    "camelize-identifier": "~1.0.0"
+  },
   "devDependencies": {
     "brfs": "^1.3.0",
     "linify": "~1.0.1",

--- a/source.js
+++ b/source.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var templateSTR = fs.readFileSync(__dirname + '/template.min.js', 'utf8');
+var camelize = require('camelize-identifier');
 
 function template(moduleName, options) {
   if (typeof options === 'boolean') {
@@ -37,42 +38,28 @@ exports.postlude = function (moduleName, options) {
   return template(moduleName, options)[1];
 };
 
-
-function camelCase(name) {
-  name = name.replace(/\-([a-z])/g, function (_, char) { return char.toUpperCase(); });
-  if (!/^[a-zA-Z_$]$/.test(name[0])) {
-    name = name.substr(1);
-  }
-  var result = name.replace(/[^\w$]+/g, '')
-  if (!result) {
-    throw new Error('Invalid JavaScript identifier resulted from camel-casing');
-  }
-  return result
-}
-
-
 function compileNamespace(name) {
   var names = name.split('.')
 
   // No namespaces, yield the best case 'global.NAME = VALUE'
   if (names.length === 1) {
-    return 'g.' + camelCase(name) + ' = f()';
+    return 'g.' + camelize(name) + ' = f()';
 
   // Acceptable case, with reasonable compilation
   } else if (names.length === 2) {
-    names = names.map(camelCase);
+    names = names.map(camelize);
     return '(g.' + names[0] + ' || (g.' + names[0] + ' = {})).' + names[1] + ' = f()';
 
   // Worst case, too many namespaces to care about
   } else {
     var valueContainer = names.pop()
     return names.map(compileNamespaceStep)
-                .concat(['g.' + camelCase(valueContainer) + ' = f()'])
+                .concat(['g.' + camelize(valueContainer) + ' = f()'])
                 .join(';');
   }
 }
 
 function compileNamespaceStep(name) {
-  name = camelCase(name);
+  name = camelize(name);
   return 'g=(g.' + name + '||(g.' + name + ' = {}))';
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,7 @@ var src = umd('sentinel-prime', 'return "sentinel"')
 var namespacedSrc = umd('sentinel.prime', 'return "sentinel"')
 var multiNamespaces = umd('a.b.c.d.e', 'return "sentinel"')
 var dollared = umd('$', 'return "sentinel"')
-var number = umd('2sentinel', 'return "sentinel"')
-var strip = umd('sentinel^', 'return "sentinel"')
 
-it('throws when no valid identifier is produced', function () {
-  assert.throws(umd.bind(null, '^!', ''), /Invalid JavaScript/)
-})
 describe('with CommonJS', function () {
   it('uses module.exports', function () {
     var module = {exports: {}}
@@ -71,15 +66,5 @@ describe('in the absense of a module system', function () {
     var glob = {}
     Function('window', src)(glob)
     assert(glob.sentinelPrime === 'sentinel')
-  })
-  it('strips invalid leading characters', function () {
-    var glob = {}
-    Function('window', number)(glob)
-    assert(glob.sentinel === 'sentinel')
-  })
-  it('removes invalid characters', function () {
-    var glob = {}
-    Function('window', strip)(glob)
-    assert(glob.sentinel === 'sentinel')
   })
 })


### PR DESCRIPTION
This implements the stricter validation (throwing instead of stripping) I proposed in #24

Closes #24 (I think)

Eventually the default could be to not modify `name` at all and just let people depend on camelize-identifier directly. 