### PR TITLE
Correctly strip numbers at the start of the name

### DIFF
--- a/source.js
+++ b/source.js
@@ -40,9 +40,7 @@ exports.postlude = function (moduleName, options) {
 
 function camelCase(name) {
   name = name.replace(/\-([a-z])/g, function (_, char) { return char.toUpperCase(); });
-  if (!/^[a-zA-Z_$]$/.test(name[0])) {
-    name = name.substr(1);
-  }
+  name = name.replace(/^[^a-zA-Z_$]+/, '');
   var result = name.replace(/[^\w$]+/g, '')
   if (!result) {
     throw new Error('Invalid JavaScript identifier resulted from camel-casing');


### PR DESCRIPTION
Previously, only the first number was stripped. With this patch, if the name contains more than one number at the beginning, all of them will be stripped, e.g `123foo` will become `foo`.