### PR TITLE
Changed the global discovery to match the official UMD templates.

### DIFF
--- a/template.js
+++ b/template.js
@@ -1,4 +1,4 @@
-;(function (f) {
+;(function (g, f) {
   // CommonJS
   if (typeof exports === "object" && typeof module !== "undefined") {
     module.exports = f();
@@ -9,22 +9,9 @@
 
   // <script>
   } else {
-    var g
-    if (typeof window !== "undefined") {
-      g = window;
-    } else if (typeof global !== "undefined") {
-      g = global;
-    } else if (typeof self !== "undefined") {
-      g = self;
-    } else {
-      // works providing we're not in "use strict";
-      // needed for Java 8 Nashorn
-      // seee https://github.com/facebook/react/issues/3037
-      g = this;
-    }
     defineNamespace()
   }
 
-})(function () {
+})(this, function () {
   source()//trick uglify-js into not minifying
 });

--- a/test/index.js
+++ b/test/index.js
@@ -32,21 +32,6 @@ describe('with amd', function () {
   })
 })
 describe('in the absense of a module system', function () {
-  it('uses window', function () {
-    var glob = {}
-    require('vm').runInNewContext(src, {window: glob})
-    assert(glob.sentinelPrime === 'sentinel')
-  })
-  it('uses global', function () {
-    var glob = {}
-    require('vm').runInNewContext(src, {global: glob})
-    assert(glob.sentinelPrime === 'sentinel')
-  })
-  it('uses self', function () {
-    var glob = {}
-    require('vm').runInNewContext(src, {self: glob})
-    assert(glob.sentinelPrime === 'sentinel')
-  })
   it('uses `this`', function () {
     var glob = {}
     require('vm').runInNewContext(src, glob)
@@ -54,32 +39,32 @@ describe('in the absense of a module system', function () {
   })
   it('creates the proper namespaces', function() {
     var glob = {}
-    Function('window', namespacedSrc)(glob)
+    require('vm').runInNewContext(namespacedSrc, glob)
     assert(glob.sentinel.prime === 'sentinel')
   })
   it('creates proper multiple namespaces', function() {
     var glob = {}
-    Function('window', multiNamespaces)(glob)
+    require('vm').runInNewContext(multiNamespaces, glob)
     assert(glob.a.b.c.d.e === 'sentinel')
   })
   it('allows the name to be a dollar', function () {
     var glob = {}
-    Function('window', dollared)(glob)
+    require('vm').runInNewContext(dollared, glob)
     assert(glob.$ === 'sentinel')
   })
   it('camelCases the name', function () {
     var glob = {}
-    Function('window', src)(glob)
+    require('vm').runInNewContext(src, glob)
     assert(glob.sentinelPrime === 'sentinel')
   })
   it('strips invalid leading characters', function () {
     var glob = {}
-    Function('window', number)(glob)
+    require('vm').runInNewContext(number, glob)
     assert(glob.sentinel === 'sentinel')
   })
   it('removes invalid characters', function () {
     var glob = {}
-    Function('window', strip)(glob)
+    require('vm').runInNewContext(strip, glob)
     assert(glob.sentinel === 'sentinel')
   })
 })


### PR DESCRIPTION
Hi, 

While looking at the generated standalone code in browserify I noticed that the UMD part differs from what the official UMD templates look like, example [here](https://github.com/umdjs/umd/blob/master/templates/returnExportsGlobal.js#L32).

After looking into it further I found out that both Webpack and Babel use very similar code for the same purpose. 
Examples can be found: [here](https://github.com/webpack/webpack/blob/9f440e30ecac00bfc27b91d372a969d3414d194c/lib/UmdMainTemplatePlugin.js#L136) and [here](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-es2015-modules-umd/src/index.js#L15).

Although the current implementation works fine I think the new one is cleaner and future proof in a sense that it offloads to the runtime the global/this detection.

Let me know what you think and if this is worth merging. 