### PR TITLE
Allow specification of more than one name for the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ options:
 
 ### umd(name, source, [options])
 
-  The `name` should the the name of the module.  Use a string like name, all lower case with hyphens instead of spaces.
+  The `name` should be the name of the module.  May also be an array of said names if you want to expose more than one name.  Use a string like name, all lower case with hyphens instead of spaces.
 
   If `source` should be a string, that is wrapped in umd and returned as a string.
 
@@ -60,6 +60,8 @@ Options:
  -h --help     Display usage information
  -c --commonJS Use CommonJS module format
  ```
+
+ `name` may be a comma-separated list of names if you want to expose more than one name.
 
  You can easilly pipe unix commands together like:
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,10 +32,11 @@ if (help || !args[0]) {
   console.log('')
   if (!help) process.exit(1)
 } else {
+  var modules = args[0].split(',')
   var source = args[1] ? read(args[1]) : process.stdin
   var dest = args[2] ? write(args[2]) : process.stdout
-  var prelude = umd.prelude(args[0], {commonJS: commonJS})
-  var postlude = umd.postlude(args[0], {commonJS: commonJS})
+  var prelude = umd.prelude(modules, {commonJS: commonJS})
+  var postlude = umd.postlude(modules, {commonJS: commonJS})
   dest.write(prelude)
   source.on('end', function () {
     dest.write(postlude + '\n')

--- a/source.js
+++ b/source.js
@@ -3,13 +3,14 @@
 var fs = require('fs');
 var templateSTR = fs.readFileSync(__dirname + '/template.min.js', 'utf8');
 
-function template(moduleName, options) {
+function template(moduleNames, options) {
+  if (typeof moduleNames === 'string') moduleNames = [moduleNames];
   if (typeof options === 'boolean') {
     options = {commonJS: options};
   } else if (!options) {
     options = {};
   }
-  var str = templateSTR.replace(/defineNamespace\(\)/g, compileNamespace(moduleName))
+  var str = templateSTR.replace(/defineNamespace\(\)/g, compileModuleNames(moduleNames))
     .split('source()')
   str[0] = str[0].trim();
   //make sure these are undefined so as to not get confused if modules have inner UMD systems
@@ -30,11 +31,11 @@ exports = module.exports = function (name, src, options) {
   return exports.prelude(name, options) + src + exports.postlude(name, options);
 };
 
-exports.prelude = function (moduleName, options) {
-  return template(moduleName, options)[0];
+exports.prelude = function (moduleNames, options) {
+  return template(moduleNames, options)[0];
 };
-exports.postlude = function (moduleName, options) {
-  return template(moduleName, options)[1];
+exports.postlude = function (moduleNames, options) {
+  return template(moduleNames, options)[1];
 };
 
 
@@ -51,28 +52,30 @@ function camelCase(name) {
 }
 
 
+function compileModuleNames(moduleNames) {
+  return moduleNames.map(compileNamespace)
+                    .concat(['f()'])
+                    .join(' = ');
+}
+
 function compileNamespace(name) {
   var names = name.split('.')
 
   // No namespaces, yield the best case 'global.NAME = VALUE'
   if (names.length === 1) {
-    return 'g.' + camelCase(name) + ' = f()';
+    return 'g.' + camelCase(name);
 
   // Acceptable case, with reasonable compilation
   } else if (names.length === 2) {
     names = names.map(camelCase);
-    return '(g.' + names[0] + ' || (g.' + names[0] + ' = {})).' + names[1] + ' = f()';
+    return '(g.' + names[0] + ' || (g.' + names[0] + ' = {})).' + names[1];
 
   // Worst case, too many namespaces to care about
   } else {
-    var valueContainer = names.pop()
-    return names.map(compileNamespaceStep)
-                .concat(['g.' + camelCase(valueContainer) + ' = f()'])
-                .join(';');
+    names[0] = 'g.' + camelCase(names[0]);
+    return names.reduce(function (prev, current, index, array) {
+             array[index] = current = camelCase(current);
+             return '(' + prev + ' || (' + array.slice(0, index).join('.') + ' = {})).' + current;
+           });
   }
-}
-
-function compileNamespaceStep(name) {
-  name = camelCase(name);
-  return 'g=(g.' + name + '||(g.' + name + ' = {}))';
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,8 @@ var assert = require('assert')
 var umd = require('../')
 var src = umd('sentinel-prime', 'return "sentinel"')
 var namespacedSrc = umd('sentinel.prime', 'return "sentinel"')
-var multiNamespaces = umd('a.b.c.d.e', 'return "sentinel"')
+var nestedNamespaces = umd('a.b.c.d.e', 'return "sentinel"')
+var multiNamespaces = umd(['a.b.c.d.e','f.g.h.i.j'], 'return "sentinel"')
 var dollared = umd('$', 'return "sentinel"')
 var number = umd('2sentinel', 'return "sentinel"')
 var strip = umd('sentinel^', 'return "sentinel"')
@@ -57,10 +58,15 @@ describe('in the absense of a module system', function () {
     Function('window', namespacedSrc)(glob)
     assert(glob.sentinel.prime === 'sentinel')
   })
+  it('creates proper nested namespaces', function() {
+    var glob = {}
+    Function('window', nestedNamespaces)(glob)
+    assert(glob.a.b.c.d.e === 'sentinel')
+  })
   it('creates proper multiple namespaces', function() {
     var glob = {}
     Function('window', multiNamespaces)(glob)
-    assert(glob.a.b.c.d.e === 'sentinel')
+    assert(glob.a.b.c.d.e === 'sentinel' && glob.f.g.h.i.j === 'sentinel')
   })
   it('allows the name to be a dollar', function () {
     var glob = {}


### PR DESCRIPTION
This is mainly useful when exporting the module to the global
namespace, e.g.: `umd(['jQuery', '$'], ...)` will yield `g.jQuery = g.$
= f()`.

Thoughts?